### PR TITLE
fix the powerpc64le target

### DIFF
--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get install -y --no-install-recommends \
         qemu-system-ppc
 
 ENV CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc \
+    QEMU_CPU=POWER8 \
     QEMU_LD_PREFIX=/usr/powerpc64le-linux-gnu \
     RUST_TEST_THREADS=1

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,12 +6,6 @@ case $1 in
         xargo build --target $1
         xargo build --target $1 --release
         ;;
-    # QEMU crashes even when executing the simplest cross compiled C program:
-    # `int main() { return 0; }`
-    powerpc64le-unknown-linux-gnu)
-        cargo test --target $1 --no-run
-        cargo test --target $1 --no-run --release
-        ;;
     *)
         cargo test --target $1
         cargo test --target $1 --release
@@ -69,9 +63,9 @@ esac
 
 # NOTE On i586, It's normal that the get_pc_thunk symbol appears several times so ignore it
 if [ $TRAVIS_OS_NAME = osx ]; then
-    path=target/${1}/debug/librustc_builtins.rlib
+    path=target/${1}/debug/libcompiler_builtins.rlib
 else
-    path=/target/${1}/debug/librustc_builtins.rlib
+    path=/target/${1}/debug/libcompiler_builtins.rlib
 fi
 
 stdout=$($PREFIX$NM -g --defined-only $path)

--- a/src/bin/intrinsics.rs
+++ b/src/bin/intrinsics.rs
@@ -1,5 +1,5 @@
 // By compiling this file we check that all the intrinsics we care about continue to be provided by
-// the `rustc_builtins` crate regardless of the changes we make to it. If we, by mistake, stop
+// the `compiler_builtins` crate regardless of the changes we make to it. If we, by mistake, stop
 // compiling a C implementation and forget to implement that intrinsic in Rust, this file will fail
 // to link due to the missing intrinsic (symbol).
 


### PR DESCRIPTION
by selecting a CPU that's compatible with the instructions that `rustc`
generates